### PR TITLE
Revert CNAME to ayab-knitting.com

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.ayab-knitting.com
+ayab-knitting.com


### PR DESCRIPTION
It looks like GitHub requires the DNS entry to actually point to `allyarnsarebeautiful.github.io` before it will generate a TLS certificate. Currently `www.ayab-knitting.com` points to `ayab-knitting.com` (which resolves to the same IP as `allyarnsarebeautiful.github.io` but that's not enough apparently).

Until this can be changed in DNS, let's revert. Sorry for the mess.