### PR TITLE
Fix serving website under www.ayab-knitting.com (take 2)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-ayab-knitting.com
+www.ayab-knitting.com


### PR DESCRIPTION
Currently www.ayab-knitting.com serves a failing certificate because GitHub Pages does not expect to serve anything under that name.

According to https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site#configuring-an-apex-domain-and-the-www-subdomain-variant this should let https://ayab-knitting.com redirect to www.ayab-knitting.com, therefore both names would work.

Reverts #14 which reverted #13, which was too early as the `www.ayab-knitting.com` CNAME didn't point to `allyarnsarebeautiful.github.io` so GitHub refused to generate a certificate.