### PR TITLE
Remove the broken embedded Twitter timeline

### DIFF
--- a/news.md
+++ b/news.md
@@ -6,7 +6,6 @@ permalink: /news/
 
 
 <div class="row">
-  <div class="col-sm-6">
     <ul class="posts">
     {% for post in site.posts %}
       <li>
@@ -16,10 +15,4 @@ permalink: /news/
     {% endfor %}
     </ul>
     <p class="rss-subscribe"><a href="{{ "/feed.xml" | prepend: site.baseurl }}">subscribe RSS</a></p>
-  </div>
-
-  <div class="col-sm-6">
-    <a class="twitter-timeline"  href="https://twitter.com/AYABApparat" data-widget-id="736927460458168320">Tweets by @AYABApparat</a>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-  </div>
 </div>


### PR DESCRIPTION
Embedding twitter timelines on websites seems to be broken for everyone since a while now.
See https://devcommunity.x.com/t/embedded-tweets-not-working/199477 for example.

Removing the widget seems better than having it show broken content.